### PR TITLE
Remove print of fsArgs

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,6 @@ func Main(args ...string) int {
 	stats := []Stat{}
 	url := fsArgs[0]
 
-	fmt.Println(fsArgs)
 	var wg sync.WaitGroup
 	for i := 0; i < *nc; i++ {
 		wg.Add(1)


### PR DESCRIPTION
Removing the forgot fmt.Println for flag Args
