### PR TITLE
Add HTTP:// as default prefix for urls

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,9 @@ func bench(url string, quantity int, threads int, stats chan Stat) {
 
 func visit(url string, stats chan Stat, tc int, wg *sync.WaitGroup) {
 	defer wg.Done()
+	if !strings.HasPrefix(url, "http") {
+        	url = "http://" + url
+	}
 	for {
 		var dnsStart, dnsDone, connDone, gotConn, transferInit, done time.Time
 		req, err := http.NewRequest("GET", url, nil)


### PR DESCRIPTION
Old behavior
$ benchstats www.github.com
017/03/26 01:11:36 request failed: Get www.github.com: unsupported protocol scheme ""
exit status 1

New behavior
$ benchstats www.github.com
200 OK
Average request time: 0.589077682s
DNS Lookup: 0.013210684s
TCP Connections: 0.135449342s
Server Procesing: 0.157549961s
Server Tranfer: 0.000324132s